### PR TITLE
Update for zig build changes in zig PR #18160

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -74,7 +74,7 @@ pub fn build(b: *std.Build) void {
     generate_libelf_artifact(b, target, optimize, config_header);
 }
 
-fn generate_libelf_artifact(b: *std.Build, target: std.zig.CrossTarget, optimize: std.builtin.Mode, config_header: *std.Build.Step.ConfigHeader) void {
+fn generate_libelf_artifact(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.Mode, config_header: *std.Build.Step.ConfigHeader) void {
     const upstream = b.dependency("elfutils", .{});
     const zlib = b.dependency("zlib", .{
         .target = target,


### PR DESCRIPTION
Hi, I wanted to try out zbpf with latest zig and noticed there had been some changes to the build system. I'm no zig expert but this builds and looked plausible to me (using zig-linux-x86_64-0.12.0-dev.2059+42389cb9c)